### PR TITLE
Patch addTwigExtension() deprecation 

### DIFF
--- a/InspectorPlugin.php
+++ b/InspectorPlugin.php
@@ -24,7 +24,7 @@ class InspectorPlugin extends BasePlugin
         return 'http://adrianmacneil.com';
     }
 
-    public function hookAddTwigExtension()
+    public function AddTwigExtension()
     {
         Craft::import('plugins.inspector.twigextensions.InspectorTwigExtension');
 


### PR DESCRIPTION
... Craft\InspectorPlugin::hookAddTwigExtension() method name has been deprecated. It should be renamed to addTwigExtension().
